### PR TITLE
undefined hostname

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -50,7 +50,7 @@ module.exports = function cacheRenderer(nuxt, config) {
     const renderer = nuxt.renderer;
     const renderRoute = renderer.renderRoute.bind(renderer);
     renderer.renderRoute = function(route, context) {
-        const hostname = context.req.hostname || context.req.host;
+      const hostname = context.req.hostname || context.req.host || context.req.headers.host;
     	const cacheKey = config.cache.useHostPrefix === true && hostname
     	                ? path.join(hostname, route)
                         : route;


### PR DESCRIPTION
I use nginx as a proxy for my nuxt application and I also use different domains on my server. 
context.req.hostname and context.req.host are undefined in my case, but real host name is available in context.req.headers.host